### PR TITLE
Use autossh instead of ssh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,6 @@ ENV SSH_AUTH_SOCK /ssh-agent
 RUN apk add --update autossh && rm -rf /var/cache/apk/*
 
 VOLUME ["/ssh-agent"]
+# for ambassador mode
+EXPOSE 2222
 ENTRYPOINT ["/usr/bin/autossh", "-M", "0", "-T", "-N", "-oStrictHostKeyChecking=no", "-L"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,15 @@
 #
 ###
 
-FROM alpine:3.2
+FROM alpine:latest
 MAINTAINER Kingsquare <docker@kingsquare.nl>
+MAINTAINER bubak4 <mar@centrum.cz>
 
 ENV SSH_AUTH_SOCK /ssh-agent
 
 ####
-# Install the SSH-client
-RUN apk add --update openssh-client && rm -rf /var/cache/apk/*
+# Install the autossh
+RUN apk add --update autossh && rm -rf /var/cache/apk/*
 
 VOLUME ["/ssh-agent"]
-EXPOSE 2222 
-ENTRYPOINT ["/usr/bin/ssh", "-T", "-N", "-o", "StrictHostKeyChecking=false", "-o", "ServerAliveInterval=180", "-L"]
+ENTRYPOINT ["/usr/bin/autossh", "-M", "0", "-T", "-N", "-oStrictHostKeyChecking=no", "-L"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+# Time-stamp: < Makefile (2017-01-10 09:11) >
+BUILD=build
+NAME=docker-tunnel
+TAG=bubak4
+IMAGE=$(NAME):$(TAG)
+VOLUME=$(shell echo "$$SSH_AUTH_SOCK:/ssh-agent")
+# change to your liking
+SSH_CMD=*:5432:localhost:5432 martin@172.17.0.1
+
+.PHONY: all clean clean-container clean-image prepare image container start
+
+all:
+	@echo "legal targets: 'clean', 'clean-container', clean-image', 'build-image', 'build-container', 'start'"
+
+clean: clean-container clean-image
+	rm -rf $(BUILD)
+
+clean-container:
+	rm -f $(BUILD)/container
+	docker rm $(NAME)
+
+clean-image:
+	rm -f $(BUILD)/image
+	docker rmi $(IMAGE)
+
+prepare:
+	mkdir -p $(BUILD)
+
+build-image: prepare $(BUILD)/image
+
+$(BUILD)/image: Dockerfile
+	docker build -f $< -t $(IMAGE) .
+	test `docker images --format '{{.ID}}' $(IMAGE) | wc -l` -eq "1" && touch $@
+
+build-container: build-image $(BUILD)/container
+
+$(BUILD)/container: Dockerfile
+	docker run -d --name $(NAME) -v $(VOLUME) $(IMAGE) $(SSH_CMD)
+	docker stop $(NAME)
+	test `docker ps --all --filter=name=$(NAME) --format '{{.ID}}' | wc -l` -eq "1" && touch $@
+
+start: build-container
+	docker start -a -i $(NAME)

--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ the image.
 The full syntax for starting an image from this container:
 
 	docker run -d --name [$your_tunnel_name] -v $SSH_AUTH_SOCK:/ssh-agent kingsquare/tunnel *:[$exposed_port]:[$destination]:[$destination_port] [$user@][$server]
-	
+
 **Mac support:** Please be aware that with the launch of the [Docker for Mac Beta](https://blog.docker.com/2016/03/docker-for-mac-windows-beta/) this currently doesnt work on Mac. Please see this [note](https://github.com/kingsquare/docker-tunnel/issues/2#issuecomment-220782052)
 
 # Examples
 
 * you would like to have a tunnel port 3306 on server example.com locally exposed as 3306
-	
+
 	```docker run -d --name tunnel_mysql -v $SSH_AUTH_SOCK:/ssh-agent kingsquare/tunnel *:3306:localhost:3306 me@example.com```
 
 * you would like to have a tunnel port 3306 on server example.com locally exposed on the host as 3308
-	
+
 	```docker run -d -p 3308:3306 --name tunnel_mysql -v $SSH_AUTH_SOCK:/ssh-agent kingsquare/tunnel *:3306:localhost:3306 me@example.com```
 
 
@@ -31,18 +31,28 @@ This method allows for using this image as an ambassador to other (secure) serve
 	docker stop staging-mongo;
 	docker rm staging-mongo;
 	docker run -d --name staging-mongo -v $SSH_AUTH_SOCK:/ssh-agent kingsquare/tunnel *:2222:127.0.0.1:27017 tunnel-user@db.staging
-	
+
 	docker stop production-mongo;
 	docker rm production-mongo;
 	docker run -d --name production-mongo -v $SSH_AUTH_SOCK:/ssh-agent kingsquare/tunnel *:2222:127.0.0.1:27017 tunnel-user@db.production
-	
+
 use the links in another container via exposed port 2222:
 
-	docker run --link staging-mongo:db.staging \ 
+	docker run --link staging-mongo:db.staging \
 	    --link production-mongo:db.production \
 	    my_app start
 
 # Changelog
+
+* 2017-01-10
+
+   - Modified image to use the `alpine:latest`
+   - Use `autossh` instead of simple `ssh` for extra stability of the tunnel
+   - Provided sample `Makefile` to automate the build process
+   - As original, the assumption is, that local `ssh-agent` holds the
+     required identity files.  Better solution probably would be to
+     generate new ssh key (`ssh-keygen`) and use the ssh `-i` option to
+     provide the identity directly
 
 * 2016-09-13
 
@@ -51,15 +61,15 @@ use the links in another container via exposed port 2222:
     - `kingsquare/tunnel:latest` (the `-L` option)
     - `kingsquare/tunnel:forward`
     - `kingsquare/tunnel:l`
-    
+
     and the reverse option: (the `-R` option)
     - `kingsquare/tunnel:reverse`
     - `kingsquare/tunnel:r`
-    
+
     Thanks @ignar for bringing this container back to my attention :)
 
 * 2015-11-10
 
-    Thanks to @ignar I took another look at the dockerfile and have updated it to use [AlpineLinux](http://www.alpinelinux.org/) 
-    This results in a _much_ smaller image (<8mb) and is still just as fast and functional. 
+    Thanks to @ignar I took another look at the dockerfile and have updated it to use [AlpineLinux](http://www.alpinelinux.org/)
+    This results in a _much_ smaller image (<8mb) and is still just as fast and functional.
     Thanks @ignar for bringing this container back to my attention :)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ use the links in another container via exposed port 2222:
    - Modified image to use the `alpine:latest`
    - Use `autossh` instead of simple `ssh` for extra stability of the tunnel
    - Provided sample `Makefile` to automate the build process
+
+	```SSH_CMD="*:6379:localhost:6379 martin@172.17.0.1" make build-container```
+
    - As original, the assumption is, that local `ssh-agent` holds the
      required identity files.  Better solution probably would be to
      generate new ssh key (`ssh-keygen`) and use the ssh `-i` option to


### PR DESCRIPTION
For extra reliability I can recommend using autossh instead of ssh (minor change in Dockerfile).

I have also added a simple (GNU) Makefile for container build and updated doc accordingly.